### PR TITLE
new: DataLoafPackageDirFmt

### DIFF
--- a/q2_stats/__init__.py
+++ b/q2_stats/__init__.py
@@ -8,13 +8,16 @@
 
 from ._version import get_versions
 from ._format import (NDJSONFileFormat, DataResourceSchemaFileFormat,
-                      TabularDataResourceDirFmt)
+                      TabularDataResourceDirFmt, DataLoafSliceFileFormat,
+                      DataLoafNutritionFactsFileFormat, DataLoafPackageDirFmt)
 from ._type import (StatsTable, Pairwise, GroupDist,
                     Ordered, Unordered, Matched, Independent)
 
 __version__ = get_versions()['version']
 del get_versions
 
-__all__ = ['NDJSONFileFormat', 'TabularDataResourceDirFmt',
-           'DataResourceSchemaFileFormat', 'StatsTable', 'Pairwise',
-           'GroupDist', 'Ordered', 'Unordered', 'Matched', 'Independent']
+__all__ = ['NDJSONFileFormat', 'DataResourceSchemaFileFormat',
+           'TabularDataResourceDirFmt', 'DataLoafPackageDirFmt',
+           'DataLoafSliceFileFormat', 'DataLoafNutritionFactsFileFormat',
+           'StatsTable', 'Pairwise', 'GroupDist', 'Ordered', 'Unordered',
+           'Matched', 'Independent']

--- a/q2_stats/__init__.py
+++ b/q2_stats/__init__.py
@@ -8,8 +8,8 @@
 
 from ._version import get_versions
 from ._format import (NDJSONFileFormat, DataResourceSchemaFileFormat,
-                      TabularDataResourceDirFmt, DataLoafSliceFileFormat,
-                      DataLoafNutritionFactsFileFormat, DataLoafPackageDirFmt)
+                      TabularDataResourceDirFmt, DataPackageSchemaFileFormat,
+                      DataLoafPackageDirFmt)
 from ._type import (StatsTable, Pairwise, GroupDist,
                     Ordered, Unordered, Matched, Independent)
 
@@ -18,6 +18,5 @@ del get_versions
 
 __all__ = ['NDJSONFileFormat', 'DataResourceSchemaFileFormat',
            'TabularDataResourceDirFmt', 'DataLoafPackageDirFmt',
-           'DataLoafSliceFileFormat', 'DataLoafNutritionFactsFileFormat',
-           'StatsTable', 'Pairwise', 'GroupDist', 'Ordered', 'Unordered',
-           'Matched', 'Independent']
+           'DataPackageSchemaFileFormat', 'StatsTable', 'Pairwise',
+           'GroupDist', 'Ordered', 'Unordered', 'Matched', 'Independent']

--- a/q2_stats/__init__.py
+++ b/q2_stats/__init__.py
@@ -8,8 +8,8 @@
 
 from ._version import get_versions
 from ._format import (NDJSONFileFormat, DataResourceSchemaFileFormat,
-                      TabularDataResourceDirFmt, DataPackageSchemaFileFormat,
-                      DataLoafPackageDirFmt)
+                      FrictionlessCSVFileFormat, TabularDataResourceDirFmt,
+                      DataPackageSchemaFileFormat, DataLoafPackageDirFmt)
 from ._type import (StatsTable, Pairwise, GroupDist,
                     Ordered, Unordered, Matched, Independent,
                     DifferentialAbundance)
@@ -18,7 +18,7 @@ __version__ = get_versions()['version']
 del get_versions
 
 __all__ = ['NDJSONFileFormat', 'DataResourceSchemaFileFormat',
-           'TabularDataResourceDirFmt', 'DataLoafPackageDirFmt',
-           'DataPackageSchemaFileFormat', 'StatsTable', 'Pairwise',
-           'GroupDist', 'Ordered', 'Unordered', 'Matched', 'Independent',
-           'DifferentialAbundance']
+           'FrictionlessCSVFileFormat', 'TabularDataResourceDirFmt',
+           'DataLoafPackageDirFmt', 'DataPackageSchemaFileFormat',
+           'StatsTable', 'Pairwise', 'GroupDist', 'Ordered', 'Unordered',
+           'Matched', 'Independent', 'DifferentialAbundance']

--- a/q2_stats/__init__.py
+++ b/q2_stats/__init__.py
@@ -11,7 +11,8 @@ from ._format import (NDJSONFileFormat, DataResourceSchemaFileFormat,
                       TabularDataResourceDirFmt, DataPackageSchemaFileFormat,
                       DataLoafPackageDirFmt)
 from ._type import (StatsTable, Pairwise, GroupDist,
-                    Ordered, Unordered, Matched, Independent)
+                    Ordered, Unordered, Matched, Independent,
+                    DifferentialAbundance)
 
 __version__ = get_versions()['version']
 del get_versions
@@ -19,4 +20,5 @@ del get_versions
 __all__ = ['NDJSONFileFormat', 'DataResourceSchemaFileFormat',
            'TabularDataResourceDirFmt', 'DataLoafPackageDirFmt',
            'DataPackageSchemaFileFormat', 'StatsTable', 'Pairwise',
-           'GroupDist', 'Ordered', 'Unordered', 'Matched', 'Independent']
+           'GroupDist', 'Ordered', 'Unordered', 'Matched', 'Independent',
+           'DifferentialAbundance']

--- a/q2_stats/_format.py
+++ b/q2_stats/_format.py
@@ -60,6 +60,7 @@ class DataLoafSliceFileFormat(model.TextFileFormat):
     def _validate_(self, level):
         pass
 
+
 class DataLoafNutritionFactsFileFormat(model.TextFileFormat):
     """Format for the associated metadata for each file in the DataLoaf.
 
@@ -67,6 +68,7 @@ class DataLoafNutritionFactsFileFormat(model.TextFileFormat):
     """
     def _validate_(self, level):
         pass
+
 
 class DataLoafPackageDirFmt(model.DirectoryFormat):
     pass

--- a/q2_stats/_format.py
+++ b/q2_stats/_format.py
@@ -9,8 +9,6 @@
 from qiime2.plugin import ValidationError, model
 
 from frictionless import validate
-import numpy as np
-import pandas as pd
 
 
 class NDJSONFileFormat(model.TextFileFormat):
@@ -29,6 +27,16 @@ class NDJSONFileFormat(model.TextFileFormat):
 class DataResourceSchemaFileFormat(model.TextFileFormat):
     """
     Format for data resource schema.
+
+    More on this later.
+    """
+    def _validate_(self, level):
+        pass
+
+
+class FrictionlessCSVFileFormat(model.TextFileFormat):
+    """
+    Format for frictionless CSV.
 
     More on this later.
     """
@@ -60,32 +68,10 @@ class DataPackageSchemaFileFormat(model.TextFileFormat):
 
 
 class DataLoafPackageDirFmt(model.DirectoryFormat):
-    data_slices = model.FileCollection(r'.+\.csv', format=NDJSONFileFormat)
+    data_slices = model.FileCollection(r'.+\.csv',
+                                       format=FrictionlessCSVFileFormat)
     nutrition_facts = model.File('datapackage.json',
                                  format=DataPackageSchemaFileFormat)
-
-    def _check_nutrition_facts(self):
-        for slice in self.data_slices.iter_views(pd.DataFrame):
-            if self.nutrition_facts.columns != slice.columns:
-                raise ValidationError('The datapackage does not completely'
-                                      ' describe the .csv files.')
-
-    def _check_matching_data_slices(self):
-        slice_lengths = []
-        slice_widths = []
-
-        for slice in self.data_slices.iter_views(pd.DataFrame):
-            slice_lengths.append(len(slice.index))
-            slice_widths.append(len(slice.columns))
-
-        if (len(np.unique(slice_lengths)) > 1
-                or len(np.unique(slice_widths)) > 1):
-            raise ValidationError('.csv files are not all the same size.')
-
-    def _validate_(self, level):
-        # self._check_matching_data_slices()
-        # self._check_nutrition_facts()
-        pass
 
     @data_slices.set_path_maker
     def _data_slices_path_maker(self, slice_name):

--- a/q2_stats/_format.py
+++ b/q2_stats/_format.py
@@ -62,5 +62,11 @@ class DataLoafPackageDirFmt(model.DirectoryFormat):
     nutrition_facts = model.File('dataresource.json',
                                  format=DataPackageSchemaFileFormat)
 
+    def _check_nutrition_facts(self):
+        pass
+
+    def _check_matching_data_slices(self):
+        pass
+
     def _validate_(self, level):
         pass

--- a/q2_stats/_format.py
+++ b/q2_stats/_format.py
@@ -60,15 +60,15 @@ class DataPackageSchemaFileFormat(model.TextFileFormat):
 
 
 class DataLoafPackageDirFmt(model.DirectoryFormat):
-    data_slices = model.FileCollection(r'.+\.ndjson', format=NDJSONFileFormat)
-    nutrition_facts = model.File('dataresource.json',
+    data_slices = model.FileCollection(r'.+\.csv', format=NDJSONFileFormat)
+    nutrition_facts = model.File('datapackage.json',
                                  format=DataPackageSchemaFileFormat)
 
     def _check_nutrition_facts(self):
         for slice in self.data_slices.iter_views(pd.DataFrame):
             if self.nutrition_facts.columns != slice.columns:
                 raise ValidationError('The datapackage does not completely'
-                                      ' describe the .ndjson files.')
+                                      ' describe the .csv files.')
 
     def _check_matching_data_slices(self):
         slice_lengths = []
@@ -80,8 +80,13 @@ class DataLoafPackageDirFmt(model.DirectoryFormat):
 
         if (len(np.unique(slice_lengths)) > 1
                 or len(np.unique(slice_widths)) > 1):
-            raise ValidationError('.ndjson files are not all the same size.')
+            raise ValidationError('.csv files are not all the same size.')
 
     def _validate_(self, level):
-        self._check_matching_data_slices()
+        # self._check_matching_data_slices()
         # self._check_nutrition_facts()
+        pass
+
+    @data_slices.set_path_maker
+    def _data_slices_path_maker(self, slice_name):
+        return slice_name + '.csv'

--- a/q2_stats/_format.py
+++ b/q2_stats/_format.py
@@ -46,3 +46,27 @@ class TabularDataResourceDirFmt(model.DirectoryFormat):
             raise model.ValidationError(
                 'The dataresource does not completely describe'
                 ' the data.ndjson file')
+
+
+class DataLoafSliceFileFormat(model.TextFileFormat):
+    """Format for files within the DataLoaf directory.
+
+    First line is headers.
+
+    All files share the same number of columns and rows.
+
+    More to be added later.
+    """
+    def _validate_(self, level):
+        pass
+
+class DataLoafNutritionFactsFileFormat(model.TextFileFormat):
+    """Format for the associated metadata for each file in the DataLoaf.
+
+    More on this later.
+    """
+    def _validate_(self, level):
+        pass
+
+class DataLoafPackageDirFmt(model.DirectoryFormat):
+    pass

--- a/q2_stats/_format.py
+++ b/q2_stats/_format.py
@@ -48,20 +48,7 @@ class TabularDataResourceDirFmt(model.DirectoryFormat):
                 ' the data.ndjson file')
 
 
-class DataLoafSliceFileFormat(model.TextFileFormat):
-    """Format for files within the DataLoaf directory.
-
-    First line is headers.
-
-    All files share the same number of columns and rows.
-
-    More to be added later.
-    """
-    def _validate_(self, level):
-        pass
-
-
-class DataLoafNutritionFactsFileFormat(model.TextFileFormat):
+class DataPackageSchemaFileFormat(model.TextFileFormat):
     """Format for the associated metadata for each file in the DataLoaf.
 
     More on this later.
@@ -71,4 +58,9 @@ class DataLoafNutritionFactsFileFormat(model.TextFileFormat):
 
 
 class DataLoafPackageDirFmt(model.DirectoryFormat):
-    pass
+    data_slices = model.FileCollection(r'.+\.ndjson', format=NDJSONFileFormat)
+    nutrition_facts = model.File('dataresource.json',
+                                 format=DataPackageSchemaFileFormat)
+
+    def _validate_(self, level):
+        pass

--- a/q2_stats/_type.py
+++ b/q2_stats/_type.py
@@ -7,6 +7,7 @@
 # ----------------------------------------------------------------------------
 
 from qiime2.plugin import SemanticType
+from q2_types.feature_data import FeatureData
 
 StatsTable = SemanticType('StatsTable', field_names=['kind'])
 
@@ -17,6 +18,9 @@ GroupDist = SemanticType('GroupDist', field_names=['order', 'dependence'])
 Ordered = SemanticType('Ordered', variant_of=GroupDist.field['order'])
 Unordered = SemanticType('Unordered', variant_of=GroupDist.field['order'])
 
-Matched = SemanticType("Matched", variant_of=GroupDist.field['dependence'])
-Independent = SemanticType("Independent",
+Matched = SemanticType('Matched', variant_of=GroupDist.field['dependence'])
+Independent = SemanticType('Independent',
                            variant_of=GroupDist.field['dependence'])
+
+DifferentialAbundance = SemanticType('DifferentialAbundance',
+                                     variant_of=FeatureData.field['type'])

--- a/q2_stats/plugin_setup.py
+++ b/q2_stats/plugin_setup.py
@@ -13,7 +13,10 @@ from qiime2.plugin import Str, Plugin, Choices
 import q2_stats
 from q2_stats._stats import mann_whitney_u, wilcoxon_srt
 from q2_stats._format import (NDJSONFileFormat, DataResourceSchemaFileFormat,
-                              TabularDataResourceDirFmt)
+                              TabularDataResourceDirFmt,
+                              DataLoafSliceFileFormat,
+                              DataLoafNutritionFactsFileFormat,
+                              DataLoafPackageDirFmt)
 from q2_stats._visualizer import plot_rainclouds
 from q2_stats._type import (StatsTable, Pairwise, GroupDist, Matched,
                             Independent, Ordered, Unordered)
@@ -28,7 +31,9 @@ plugin = Plugin(name='stats',
                 short_description='Plugin for statistical analyses.')
 
 plugin.register_formats(NDJSONFileFormat, DataResourceSchemaFileFormat,
-                        TabularDataResourceDirFmt)
+                        TabularDataResourceDirFmt, DataLoafSliceFileFormat,
+                        DataLoafNutritionFactsFileFormat,
+                        DataLoafPackageDirFmt)
 plugin.register_semantic_types(StatsTable, Pairwise, GroupDist, Matched,
                                Independent, Ordered, Unordered)
 

--- a/q2_stats/plugin_setup.py
+++ b/q2_stats/plugin_setup.py
@@ -14,8 +14,7 @@ import q2_stats
 from q2_stats._stats import mann_whitney_u, wilcoxon_srt
 from q2_stats._format import (NDJSONFileFormat, DataResourceSchemaFileFormat,
                               TabularDataResourceDirFmt,
-                              DataLoafSliceFileFormat,
-                              DataLoafNutritionFactsFileFormat,
+                              DataPackageSchemaFileFormat,
                               DataLoafPackageDirFmt)
 from q2_stats._visualizer import plot_rainclouds
 from q2_stats._type import (StatsTable, Pairwise, GroupDist, Matched,
@@ -31,8 +30,7 @@ plugin = Plugin(name='stats',
                 short_description='Plugin for statistical analyses.')
 
 plugin.register_formats(NDJSONFileFormat, DataResourceSchemaFileFormat,
-                        TabularDataResourceDirFmt, DataLoafSliceFileFormat,
-                        DataLoafNutritionFactsFileFormat,
+                        TabularDataResourceDirFmt, DataPackageSchemaFileFormat,
                         DataLoafPackageDirFmt)
 plugin.register_semantic_types(StatsTable, Pairwise, GroupDist, Matched,
                                Independent, Ordered, Unordered)

--- a/q2_stats/plugin_setup.py
+++ b/q2_stats/plugin_setup.py
@@ -13,7 +13,9 @@ from q2_types.feature_data import FeatureData
 
 import q2_stats
 from q2_stats._stats import mann_whitney_u, wilcoxon_srt
-from q2_stats._format import (NDJSONFileFormat, DataResourceSchemaFileFormat,
+from q2_stats._format import (NDJSONFileFormat,
+                              DataResourceSchemaFileFormat,
+                              FrictionlessCSVFileFormat,
                               TabularDataResourceDirFmt,
                               DataPackageSchemaFileFormat,
                               DataLoafPackageDirFmt)
@@ -32,8 +34,8 @@ plugin = Plugin(name='stats',
                 short_description='Plugin for statistical analyses.')
 
 plugin.register_formats(NDJSONFileFormat, DataResourceSchemaFileFormat,
-                        TabularDataResourceDirFmt, DataPackageSchemaFileFormat,
-                        DataLoafPackageDirFmt)
+                        FrictionlessCSVFileFormat, TabularDataResourceDirFmt,
+                        DataPackageSchemaFileFormat, DataLoafPackageDirFmt)
 
 plugin.register_semantic_types(StatsTable, Pairwise, GroupDist, Matched,
                                Independent, Ordered, Unordered,

--- a/q2_stats/plugin_setup.py
+++ b/q2_stats/plugin_setup.py
@@ -9,6 +9,7 @@
 import importlib
 
 from qiime2.plugin import Str, Plugin, Choices
+from q2_types.feature_data import FeatureData
 
 import q2_stats
 from q2_stats._stats import mann_whitney_u, wilcoxon_srt
@@ -18,7 +19,8 @@ from q2_stats._format import (NDJSONFileFormat, DataResourceSchemaFileFormat,
                               DataLoafPackageDirFmt)
 from q2_stats._visualizer import plot_rainclouds
 from q2_stats._type import (StatsTable, Pairwise, GroupDist, Matched,
-                            Independent, Ordered, Unordered)
+                            Independent, Ordered, Unordered,
+                            DifferentialAbundance)
 import q2_stats._examples as ex
 
 plugin = Plugin(name='stats',
@@ -32,13 +34,17 @@ plugin = Plugin(name='stats',
 plugin.register_formats(NDJSONFileFormat, DataResourceSchemaFileFormat,
                         TabularDataResourceDirFmt, DataPackageSchemaFileFormat,
                         DataLoafPackageDirFmt)
+
 plugin.register_semantic_types(StatsTable, Pairwise, GroupDist, Matched,
-                               Independent, Ordered, Unordered)
+                               Independent, Ordered, Unordered,
+                               DifferentialAbundance)
 
 plugin.register_semantic_type_to_format(
     GroupDist[Ordered | Unordered,
               Matched | Independent] | StatsTable[Pairwise],
     TabularDataResourceDirFmt)
+plugin.register_semantic_type_to_format(
+    FeatureData[DifferentialAbundance], DataLoafPackageDirFmt)
 
 plugin.methods.register_function(
     function=mann_whitney_u,


### PR DESCRIPTION
This adds three new formats:

**DataLoafPackageDirFmt**
**DataPackageSchemaFileFormat**
**FrictionlessCSVFileFormat**

The `DataLoafPackageDirFmt` is intended for artifacts containing multiple files of the same size (number of columns & rows). The analogy here is a 'loaf' of data containing identical data 'slices (i.e. files) with each file in the form of a `FrictionlessCSVFileFormat`. The loaf also contains 'nutrition facts' (metadata for the data slices) in the form of a `DataPackageSchemaFileFormat`.

This PR does not include comprehensive validation for the DataLoafPackageDirFmt or for the FrictionlessCSVFileFormat - that functionality will be addressed in a subsequent PR connected to [this issue](https://github.com/qiime2/q2-stats/issues/8).