### PR TITLE
NEW: ignore_empty_comparator parameter in wilcoxon method

### DIFF
--- a/q2_stats/_stats.py
+++ b/q2_stats/_stats.py
@@ -240,7 +240,7 @@ def _compare_wilcoxon(group_a, group_b, alternative, p_val_approx,
         if ignore_empty_comparator:
             stat = float('nan')
             p_val = float('nan')
-        elif not ignore_empty_comparator:
+        else:
             raise ValueError("There is no subject overlap between Group %s and"
                              " Group %s. There has to be at least 1 subject"
                              " overlap between the groups. Group %s contains"

--- a/q2_stats/_stats.py
+++ b/q2_stats/_stats.py
@@ -132,7 +132,7 @@ def _compare_mannwhitneyu(group_a, group_b, alternative, p_val_approx):
 def wilcoxon_srt(distribution: pd.DataFrame, compare: str,
                  baseline_group: str = None,
                  alternative: str = 'two-sided',
-                 p_val_approx: str = 'auto', 
+                 p_val_approx: str = 'auto',
                  ignore_empty_comparator: bool = False) -> pd.DataFrame:
 
     if compare == 'baseline':
@@ -162,7 +162,7 @@ def wilcoxon_srt(distribution: pd.DataFrame, compare: str,
         group_b.index.name = comp_b
 
         row = _compare_wilcoxon(group_a, group_b, alternative, p_val_approx,
-                               ignore_empty_comparator)
+                                ignore_empty_comparator)
 
         row['A:group'] = comp_a
         row['B:group'] = comp_b
@@ -217,7 +217,7 @@ def _comp_consecutive(distribution):
     yield from zip(timepoints, timepoints[1:])
 
 
-def _compare_wilcoxon(group_a, group_b, alternative, p_val_approx, 
+def _compare_wilcoxon(group_a, group_b, alternative, p_val_approx,
                       ignore_empty_comparator) -> dict:
     if p_val_approx == 'asymptotic':
         # wilcoxon differs from mannwhitneyu in arg value, but does the same
@@ -240,15 +240,17 @@ def _compare_wilcoxon(group_a, group_b, alternative, p_val_approx,
         if ignore_empty_comparator:
             stat = float('nan')
             p_val = float('nan')
-        elif ignore_empty_comparator == False: 
+        elif not ignore_empty_comparator:
             raise ValueError("There is no subject overlap between Group %s and"
                              " Group %s. There has to be at least 1 subject"
                              " overlap between the groups. Group %s contains"
                              " these subjects: %s and Group %s contains these"
-                             " subjects: %s" %(group_a.index.name, 
-                             group_b.index.name, group_a.index.name, 
-                             list(group_a.index), group_b.index.name,
-                             list(group_b.index)))
+                             " subjects: %s" % (group_a.index.name,
+                                                group_b.index.name,
+                                                group_a.index.name,
+                                                list(group_a.index),
+                                                group_b.index.name,
+                                                list(group_b.index)))
     else:
         stat, p_val = scipy.stats.wilcoxon(
             filtered.iloc[:, 0], filtered.iloc[:, 1],

--- a/q2_stats/_stats.py
+++ b/q2_stats/_stats.py
@@ -132,7 +132,8 @@ def _compare_mannwhitneyu(group_a, group_b, alternative, p_val_approx):
 def wilcoxon_srt(distribution: pd.DataFrame, compare: str,
                  baseline_group: str = None,
                  alternative: str = 'two-sided',
-                 p_val_approx: str = 'auto') -> pd.DataFrame:
+                 p_val_approx: str = 'auto', 
+                 ignore_empty_comparator: bool = False) -> pd.DataFrame:
 
     if compare == 'baseline':
         comparisons = _comp_baseline(distribution, baseline_group)
@@ -156,9 +157,12 @@ def wilcoxon_srt(distribution: pd.DataFrame, compare: str,
         group_b = distribution[distribution['group'] == comp_b]
 
         group_a = group_a.set_index('subject')['measure']
+        group_a.index.name = comp_a
         group_b = group_b.set_index('subject')['measure']
+        group_b.index.name = comp_b
 
-        row = _compare_wilcoxon(group_a, group_b, alternative, p_val_approx)
+        row = _compare_wilcoxon(group_a, group_b, alternative, p_val_approx,
+                               ignore_empty_comparator)
 
         row['A:group'] = comp_a
         row['B:group'] = comp_b
@@ -213,7 +217,8 @@ def _comp_consecutive(distribution):
     yield from zip(timepoints, timepoints[1:])
 
 
-def _compare_wilcoxon(group_a, group_b, alternative, p_val_approx) -> dict:
+def _compare_wilcoxon(group_a, group_b, alternative, p_val_approx, 
+                      ignore_empty_comparator) -> dict:
     if p_val_approx == 'asymptotic':
         # wilcoxon differs from mannwhitneyu in arg value, but does the same
         # test using a normal dist instead of the permutational dist so
@@ -231,9 +236,23 @@ def _compare_wilcoxon(group_a, group_b, alternative, p_val_approx) -> dict:
         'n': len(filtered.index),
     }
 
-    stat, p_val = scipy.stats.wilcoxon(
-        filtered.iloc[:, 0], filtered.iloc[:, 1],
-        nan_policy='raise', mode=p_val_approx, alternative=alternative)
+    if filtered.empty:
+        if ignore_empty_comparator:
+            stat = float('nan')
+            p_val = float('nan')
+        elif ignore_empty_comparator == False: 
+            raise ValueError("There is no subject overlap between Group %s and"
+                             " Group %s. There has to be at least 1 subject"
+                             " overlap between the groups. Group %s contains"
+                             " these subjects: %s and Group %s contains these"
+                             " subjects: %s" %(group_a.index.name, 
+                             group_b.index.name, group_a.index.name, 
+                             list(group_a.index), group_b.index.name,
+                             list(group_b.index)))
+    else:
+        stat, p_val = scipy.stats.wilcoxon(
+            filtered.iloc[:, 0], filtered.iloc[:, 1],
+            nan_policy='raise', mode=p_val_approx, alternative=alternative)
 
     results['test-statistic'] = stat
     results['p-value'] = p_val

--- a/q2_stats/plugin_setup.py
+++ b/q2_stats/plugin_setup.py
@@ -118,9 +118,9 @@ plugin.methods.register_function(
                         ' and "auto" will use either "exact" or "approx"'
                         ' depending on size.',
         'ignore_empty_comparator': 'Ignore any group that does not have any'
-                                   ' overlapping subjects with comparison group'
-                                   '. These groups will written as Nan in the'
-                                   ' stats table output'
+                                   ' overlapping subjects with comparison'
+                                   ' group. These groups will written as Nan'
+                                   ' in the stats table output'
     },
     output_descriptions={
         'stats': 'The Wilcoxon SRT table for either the "baseline"'

--- a/q2_stats/plugin_setup.py
+++ b/q2_stats/plugin_setup.py
@@ -119,7 +119,7 @@ plugin.methods.register_function(
                         ' depending on size.',
         'ignore_empty_comparator': 'Ignore any group that does not have any'
                                    ' overlapping subjects with comparison'
-                                   ' group. These groups will written as Nan'
+                                   ' group. These groups will have NaNs'
                                    ' in the stats table output'
     },
     output_descriptions={

--- a/q2_stats/plugin_setup.py
+++ b/q2_stats/plugin_setup.py
@@ -8,7 +8,7 @@
 
 import importlib
 
-from qiime2.plugin import Str, Plugin, Choices
+from qiime2.plugin import Str, Plugin, Choices, Bool
 
 import q2_stats
 from q2_stats._stats import mann_whitney_u, wilcoxon_srt
@@ -90,7 +90,8 @@ plugin.methods.register_function(
     parameters={'compare': Str % Choices('baseline', 'consecutive'),
                 'baseline_group': Str,
                 'alternative': Str % Choices('two-sided', 'greater', 'less'),
-                'p_val_approx': Str % Choices('auto', 'exact', 'asymptotic')},
+                'p_val_approx': Str % Choices('auto', 'exact', 'asymptotic'),
+                'ignore_empty_comparator': Bool},
     outputs=[('stats', StatsTable[Pairwise])],
     parameter_descriptions={
         'compare': 'The type of comparison that will be used to analyze the'
@@ -115,7 +116,11 @@ plugin.methods.register_function(
                         ' distributions of up to 25 (inclusive) measurements,'
                         ' "asymptotic" will use a normal distribution,'
                         ' and "auto" will use either "exact" or "approx"'
-                        ' depending on size.'
+                        ' depending on size.',
+        'ignore_empty_comparator': 'Ignore any group that does not have any'
+                                   ' overlapping subjects with comparison group'
+                                   '. These groups will written as Nan in the'
+                                   ' stats table output'
     },
     output_descriptions={
         'stats': 'The Wilcoxon SRT table for either the "baseline"'

--- a/q2_stats/tests/test_stats.py
+++ b/q2_stats/tests/test_stats.py
@@ -12,7 +12,7 @@ import numpy as np
 from qiime2.plugin.testing import TestPluginBase
 from qiime2.plugin import ValidationError
 
-from q2_stats._stats import wilcoxon_srt, mann_whitney_u
+from q2_stats._stats import wilcoxon_srt, mann_whitney_u, _compare_wilcoxon
 from q2_stats._examples import (faithpd_timedist_factory,
                                 faithpd_refdist_factory)
 from q2_stats._format import TabularDataResourceDirFmt
@@ -231,6 +231,60 @@ class TestStats(TestBase):
 
     def test_examples(self):
         self.execute_examples()
+    def test_ignore_comparator_false(self):
+        groupa_dict = {"subject1" : 0.8091,
+                       "subject2": 0.09271, "subject3": 0.9290}
+        groupa = pd.Series(data=groupa_dict, index=['subject1', 'subject2',
+                                                    'subject3'])
+        groupa.index.name = 1
+        groupb = {"subject4" : 0.1809, "subject5": 0.9271, "subject6": 0.0290}
+        groupb = pd.Series(data=groupb, index=['subject4', 'subject5',
+                                               'subject6'])
+        groupb.index.name = 2
+
+        with self.assertRaisesRegex(ValueError, ".*no subject overlap between"
+                                    " Group 1 and Group 2.*['subject1',"
+                                    " 'subject2', 'subject3'].*['subject4',"
+                                    " 'subject5', 'subject6']"):
+                _compare_wilcoxon(group_a = groupa, group_b = groupb,
+                                  alternative = 'two-sided', 
+                                  p_val_approx = 'auto', 
+                                  ignore_empty_comparator = False)
+    def test_ignore_comparator_true(self):
+        wil_stats_data = pd.DataFrame({
+            'id': ["sample1", "sample2", "sample3","sample4"],
+            'measure': [0.9002, 0.8221 , 0.0981 , 0.0100],
+            'group': [1, 1, 2, 2],
+            'subject': ["subject1", "subject2", "subject3", "subject4"]
+        })
+
+        wil_stats_data['id'].attrs.update({
+            'title': 'Pairwise Comparison'})
+        wil_stats_data['measure'].attrs.update({
+            'title': 'Pairwise Comparison'})
+        stats_data = wilcoxon_srt(wil_stats_data, compare= 'baseline',
+                                  baseline_group=1 ,
+                                  ignore_empty_comparator= True)
+        exp_stats_data = pd.DataFrame({
+            'A:group': [1],
+            'A:n': [2],
+            'A:measure':  [0.8611500000000001],
+            'B:group': [2],
+            'B:n': [2],
+            'B:measure': [0.05405],
+            'n': [0],
+            'test-statistic': [float("Nan")],
+            'p-value': [float("Nan")],
+            'q-value': [float("Nan")]})
+        for x in stats_data.values:
+            print(x)
+        print("________________________")
+        print(exp_stats_data)
+        
+        pd.testing.assert_frame_equal(stats_data, exp_stats_data)
+
+
+
 
 
 class TestTransformers(TestBase):

--- a/q2_stats/tests/test_stats.py
+++ b/q2_stats/tests/test_stats.py
@@ -231,13 +231,14 @@ class TestStats(TestBase):
 
     def test_examples(self):
         self.execute_examples()
+
     def test_ignore_comparator_false(self):
-        groupa_dict = {"subject1" : 0.8091,
+        groupa_dict = {"subject1": 0.8091,
                        "subject2": 0.09271, "subject3": 0.9290}
         groupa = pd.Series(data=groupa_dict, index=['subject1', 'subject2',
                                                     'subject3'])
         groupa.index.name = 1
-        groupb = {"subject4" : 0.1809, "subject5": 0.9271, "subject6": 0.0290}
+        groupb = {"subject4": 0.1809, "subject5": 0.9271, "subject6": 0.0290}
         groupb = pd.Series(data=groupb, index=['subject4', 'subject5',
                                                'subject6'])
         groupb.index.name = 2
@@ -246,14 +247,15 @@ class TestStats(TestBase):
                                     " Group 1 and Group 2.*['subject1',"
                                     " 'subject2', 'subject3'].*['subject4',"
                                     " 'subject5', 'subject6']"):
-                _compare_wilcoxon(group_a = groupa, group_b = groupb,
-                                  alternative = 'two-sided', 
-                                  p_val_approx = 'auto', 
-                                  ignore_empty_comparator = False)
+            _compare_wilcoxon(group_a=groupa, group_b=groupb,
+                              alternative='two-sided',
+                              p_val_approx='auto',
+                              ignore_empty_comparator=False)
+
     def test_ignore_comparator_true(self):
         wil_stats_data = pd.DataFrame({
-            'id': ["sample1", "sample2", "sample3","sample4"],
-            'measure': [0.9002, 0.8221 , 0.0981 , 0.0100],
+            'id': ["sample1", "sample2", "sample3", "sample4"],
+            'measure': [0.9002, 0.8221, 0.0981, 0.0100],
             'group': [1, 1, 2, 2],
             'subject': ["subject1", "subject2", "subject3", "subject4"]
         })
@@ -262,9 +264,9 @@ class TestStats(TestBase):
             'title': 'Pairwise Comparison'})
         wil_stats_data['measure'].attrs.update({
             'title': 'Pairwise Comparison'})
-        stats_data = wilcoxon_srt(wil_stats_data, compare= 'baseline',
-                                  baseline_group=1 ,
-                                  ignore_empty_comparator= True)
+        stats_data = wilcoxon_srt(wil_stats_data, compare='baseline',
+                                  baseline_group=1,
+                                  ignore_empty_comparator=True)
         exp_stats_data = pd.DataFrame({
             'A:group': [1],
             'A:n': [2],
@@ -276,15 +278,8 @@ class TestStats(TestBase):
             'test-statistic': [float("Nan")],
             'p-value': [float("Nan")],
             'q-value': [float("Nan")]})
-        for x in stats_data.values:
-            print(x)
-        print("________________________")
-        print(exp_stats_data)
-        
+
         pd.testing.assert_frame_equal(stats_data, exp_stats_data)
-
-
-
 
 
 class TestTransformers(TestBase):


### PR DESCRIPTION
Fixing N=0 error in wilcoxon method to be more informative. It now lists the subjects that do not overlap in the groups. Added Ignore_empty_comparator parameter that fills invalid comparisons with Nan in the stats table if used. 