### PR TITLE
new: frictionlessCSV -> dataframe transformer

### DIFF
--- a/q2_stats/_transformer.py
+++ b/q2_stats/_transformer.py
@@ -11,7 +11,9 @@ import frictionless as fls
 from frictionless import Resource
 
 from q2_stats.plugin_setup import plugin
-from q2_stats._format import (NDJSONFileFormat, DataResourceSchemaFileFormat,
+from q2_stats._format import (NDJSONFileFormat,
+                              DataResourceSchemaFileFormat,
+                              FrictionlessCSVFileFormat,
                               TabularDataResourceDirFmt)
 
 
@@ -72,3 +74,11 @@ def _4(obj: pd.DataFrame) -> TabularDataResourceDirFmt:
     metadata_resource.to_json(str(dir_fmt.path/'dataresource.json'))
 
     return dir_fmt
+
+
+@plugin.register_transformer
+def _5(obj: FrictionlessCSVFileFormat) -> pd.DataFrame:
+    path = obj.view(FrictionlessCSVFileFormat)
+    df = pd.read_csv(str(path))
+
+    return df

--- a/q2_stats/tests/data/data_slice.csv
+++ b/q2_stats/tests/data/data_slice.csv
@@ -1,0 +1,2 @@
+feature_id,bodysiteleft palm,bodysiteright palm,bodysitetongue,animalcat,animalcow,animalbird
+sample1,-4.391278379,-3.390748186,-4.326335562,1.152330146,1.45003133,2.029340857

--- a/q2_stats/tests/test_stats.py
+++ b/q2_stats/tests/test_stats.py
@@ -15,7 +15,8 @@ from qiime2.plugin import ValidationError
 from q2_stats._stats import wilcoxon_srt, mann_whitney_u
 from q2_stats._examples import (faithpd_timedist_factory,
                                 faithpd_refdist_factory)
-from q2_stats._format import TabularDataResourceDirFmt
+from q2_stats._format import (TabularDataResourceDirFmt,
+                              FrictionlessCSVFileFormat)
 from q2_stats._validator import (validate_all_dist_columns_present,
                                  validate_unique_subjects_within_group)
 
@@ -240,6 +241,22 @@ class TestTransformers(TestBase):
                                        filename='empty_data_dist')
 
         exp = pd.DataFrame(columns=['id', 'measure', 'group', 'subject'])
+
+        pd.testing.assert_frame_equal(obs, exp)
+
+    def test_frictionless_csv_to_dataframe(self):
+        _, obs = self.transform_format(FrictionlessCSVFileFormat, pd.DataFrame,
+                                       filename='data_slice.csv')
+
+        exp = pd.DataFrame({
+            'feature_id': ['sample1'],
+            'bodysiteleft palm': [-4.391278379],
+            'bodysiteright palm': [-3.390748186],
+            'bodysitetongue': [-4.326335562],
+            'animalcat': [1.152330146],
+            'animalcow': [1.45003133],
+            'animalbird': [2.029340857]
+        })
 
         pd.testing.assert_frame_equal(obs, exp)
 


### PR DESCRIPTION
This PR adds a new transformer from the `FrictionlessCSVFileFormat` to a pandas DataFrame. Unit test was added as well to confirm successful behavior. This is being added so that individual slices within the `DataLoafPackageDirFmt` can be viewed as dataframes for testing within ANCOM-BC in q2-composition.