### PR TITLE
NEW: Semantic Types for GroupDist[Multi, Matched|Independent] and NestedGroupDist

### DIFF
--- a/q2_stats/__init__.py
+++ b/q2_stats/__init__.py
@@ -10,8 +10,8 @@ from ._version import get_versions
 from ._format import (NDJSONFileFormat, DataResourceSchemaFileFormat,
                       FrictionlessCSVFileFormat, TabularDataResourceDirFmt,
                       DataPackageSchemaFileFormat, DataLoafPackageDirFmt)
-from ._type import (StatsTable, Pairwise, GroupDist,
-                    Ordered, Unordered, Matched, Independent,
+from ._type import (StatsTable, Pairwise, GroupDist, NestedGroupDist, Ordered,
+                    Unordered, Multi, Matched, Independent,
                     DifferentialAbundance)
 
 __version__ = get_versions()['version']
@@ -20,5 +20,6 @@ del get_versions
 __all__ = ['NDJSONFileFormat', 'DataResourceSchemaFileFormat',
            'FrictionlessCSVFileFormat', 'TabularDataResourceDirFmt',
            'DataLoafPackageDirFmt', 'DataPackageSchemaFileFormat',
-           'StatsTable', 'Pairwise', 'GroupDist', 'Ordered', 'Unordered',
-           'Matched', 'Independent', 'DifferentialAbundance']
+           'StatsTable', 'Pairwise', 'GroupDist', 'NestedGroupDist',
+           'Ordered', 'Unordered', 'Multi', 'Matched', 'Independent',
+           'DifferentialAbundance']

--- a/q2_stats/_type.py
+++ b/q2_stats/_type.py
@@ -15,12 +15,22 @@ Pairwise = SemanticType('Pairwise', variant_of=StatsTable.field['kind'])
 
 GroupDist = SemanticType('GroupDist', field_names=['order', 'dependence'])
 
-Ordered = SemanticType('Ordered', variant_of=GroupDist.field['order'])
-Unordered = SemanticType('Unordered', variant_of=GroupDist.field['order'])
+NestedGroupDist = SemanticType('NestedGroupDist', field_names=['order',
+                                                               'dependence'])
 
-Matched = SemanticType('Matched', variant_of=GroupDist.field['dependence'])
+Ordered = SemanticType('Ordered', variant_of=(GroupDist.field['order'],
+                                              NestedGroupDist.field['order']))
+Unordered = SemanticType('Unordered',
+                         variant_of=(GroupDist.field['order'],
+                                     NestedGroupDist.field['order']))
+Multi = SemanticType('Multi', variant_of=GroupDist.field['order'])
+
+Matched = SemanticType('Matched',
+                       variant_of=(GroupDist.field['dependence'],
+                                   NestedGroupDist.field['dependence']))
 Independent = SemanticType('Independent',
-                           variant_of=GroupDist.field['dependence'])
+                           variant_of=(GroupDist.field['dependence'],
+                                       NestedGroupDist.field['dependence']))
 
 DifferentialAbundance = SemanticType('DifferentialAbundance',
                                      variant_of=FeatureData.field['type'])

--- a/q2_stats/plugin_setup.py
+++ b/q2_stats/plugin_setup.py
@@ -21,8 +21,8 @@ from q2_stats._format import (NDJSONFileFormat,
                               DataPackageSchemaFileFormat,
                               DataLoafPackageDirFmt)
 from q2_stats._visualizer import plot_rainclouds
-from q2_stats._type import (StatsTable, Pairwise, GroupDist, Matched,
-                            Independent, Ordered, Unordered,
+from q2_stats._type import (StatsTable, Pairwise, GroupDist, NestedGroupDist,
+                            Matched, Independent, Ordered, Unordered, Multi,
                             DifferentialAbundance)
 import q2_stats._examples as ex
 
@@ -38,13 +38,17 @@ plugin.register_formats(NDJSONFileFormat, DataResourceSchemaFileFormat,
                         FrictionlessCSVFileFormat, TabularDataResourceDirFmt,
                         DataPackageSchemaFileFormat, DataLoafPackageDirFmt)
 
-plugin.register_semantic_types(StatsTable, Pairwise, GroupDist, Matched,
-                               Independent, Ordered, Unordered,
+plugin.register_semantic_types(StatsTable, Pairwise, GroupDist,
+                               NestedGroupDist, Matched, Independent,
+                               Ordered, Unordered, Multi,
                                DifferentialAbundance)
 
 plugin.register_semantic_type_to_format(
-    GroupDist[Ordered | Unordered,
-              Matched | Independent] | StatsTable[Pairwise],
+    GroupDist[Ordered | Unordered | Multi,
+              Matched | Independent] |
+    NestedGroupDist[Ordered | Unordered,
+                    Matched | Independent] |
+    StatsTable[Pairwise],
     TabularDataResourceDirFmt)
 plugin.register_semantic_type_to_format(
     FeatureData[DifferentialAbundance], DataLoafPackageDirFmt)


### PR DESCRIPTION
This PR adds the following new Semantic Types:

`GroupDist[Multi, Matched | Independent]`
`NestedGroupDist`

These will be used in new q2-stats methods for comparing groups distributions. 
These semantic types will help add functionality for comparing multiple groups using Wilcoxon-SRT and Mann-Whitney-U and correcting all comparisons easily.