### PR TITLE
MAINT: more frictionless API changes

### DIFF
--- a/q2_stats/_transformer.py
+++ b/q2_stats/_transformer.py
@@ -32,7 +32,8 @@ def _2(obj: DataResourceSchemaFileFormat) -> fls.Resource:
 def _3(df: TabularDataResourceDirFmt) -> pd.DataFrame:
     path = df.data.view(NDJSONFileFormat)
     data = pd.read_json(str(path), lines=True)
-    resource = df.metadata.view(fls.Resource)
+    schema = fls.Schema(data)
+    resource = fls.Resource(source=df.metadata, schema=schema)
 
     if data.empty:
         data = pd.DataFrame(

--- a/q2_stats/_transformer.py
+++ b/q2_stats/_transformer.py
@@ -32,8 +32,7 @@ def _2(obj: DataResourceSchemaFileFormat) -> fls.Resource:
 def _3(df: TabularDataResourceDirFmt) -> pd.DataFrame:
     path = df.data.view(NDJSONFileFormat)
     data = pd.read_json(str(path), lines=True)
-    schema = fls.Schema(data)
-    resource = fls.Resource(source=df.metadata, schema=schema)
+    resource = df.metadata.view(fls.Resource)
 
     if data.empty:
         data = pd.DataFrame(
@@ -66,7 +65,7 @@ def _4(obj: pd.DataFrame) -> TabularDataResourceDirFmt:
 
         metadata_obj.append(metadata)
 
-    metadata_dict = {'schema': metadata_obj}
+    metadata_dict = {'schema': {'fields': metadata_obj}}
     metadata_dict['format'] = 'ndjson'
     metadata_dict['path'] = 'data.ndjson'
 


### PR DESCRIPTION
This PR addresses q2-FMT test failures caused by frictionless API changes that utilize the TabularDataResourceDirFmt -> DF transformer.